### PR TITLE
Adjust header size in sidebar

### DIFF
--- a/src/SummerViewAdmin.tsx
+++ b/src/SummerViewAdmin.tsx
@@ -498,7 +498,7 @@ const SummerViewAdmin = () => {
                 <h4 className="font-semibold text-red-900 mb-2">Critical Issues</h4>
                 <div className="space-y-2 text-sm">
                   <div className="flex justify-between">
-                    <span className="text-red-700">Password < 8 chars</span>
+                    <span className="text-red-700">Password &lt; 8 chars</span>
                     <span className="font-semibold text-red-900">12 users</span>
                   </div>
                   <div className="flex justify-between">
@@ -515,7 +515,7 @@ const SummerViewAdmin = () => {
                 <h4 className="font-semibold text-yellow-900 mb-2">Warning Issues</h4>
                 <div className="space-y-2 text-sm">
                   <div className="flex justify-between">
-                    <span className="text-yellow-700">Age > 90 days</span>
+                    <span className="text-yellow-700">Age &gt; 90 days</span>
                     <span className="font-semibold text-yellow-900">156 users</span>
                   </div>
                   <div className="flex justify-between">

--- a/src/index.css
+++ b/src/index.css
@@ -31,10 +31,6 @@ body {
   min-height: 100vh;
 }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
 
 button {
   border-radius: 8px;


### PR DESCRIPTION
## Summary
- remove global h1 CSS that overrode Tailwind font sizing

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686068fee51c832399083c57e723fc5e